### PR TITLE
do not use unsafePerformIO

### DIFF
--- a/raw/embedded/src/TestHarness.hs
+++ b/raw/embedded/src/TestHarness.hs
@@ -40,17 +40,15 @@ import Data.List                        (elem, intercalate, notElem, null)
 import Language.Haskell.Exts
   (Decl (..), Exp (..), Match (..) , Module (..), Name (..), ParseResult (..), Pat (..),
    Rhs (..), SrcSpanInfo, classifyExtension, parseFileContentsWithExts)
-import System.IO.Unsafe                 (unsafePerformIO) -- We need to run the tests inside the interpreter
 import System.Random                    (randomRIO)
 import Test.HUnit.Base
   (Node (Label), Test, Counts (Counts), errors, failures, path, performTest)
 import Test.HUnit.Text                  (showPath)
 
 {-| Function called by the interpreter, getting the tests to run as the argument. -}
-run :: HU.Testable t => [t] -> (HU.Counts, ShowS)
+run :: HU.Testable t => [t] -> IO (HU.Counts, ShowS)
 run testables =
-  unsafePerformIO $
-    catches
+  catches
     (foldM performTestUnlessError (Counts 0 0 0 0, id) testables)
     [Handler $ \(e :: ErrorCall)        -> pairWith e,
      Handler $ \(e :: PatternMatchFail) -> pairWith e,

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -583,18 +583,20 @@ matchTemplate reject config context exts template submission = do
 deriving instance Typeable Counts
 
 handleCounts
-  :: Monad m
+  :: MonadIO m
   => (forall a. Doc -> m a)
   -> (Doc -> m ())
-  -> (Counts, String -> String)
+  -> IO (Counts, String -> String)
   -> m ()
-handleCounts reject inform result = case result of
-  (Counts {errors=a,failures=0} ,f) | a /= 0 -> do
-    inform "Some error occurred before fully testing the solution:"
-    reject (string (f ""))
-    -- e.g. quickcheck timeout errors
-  (Counts {errors=0, failures=0},_) -> return ()
-  (_                            ,f) -> reject (string (f ""))
+handleCounts reject inform runResult = do
+  result <- liftIO runResult
+  case result of
+    (Counts {errors=x, failures=0}, f) | x /= 0 -> do
+      inform "Some error occurred before fully testing the solution:"
+      reject (string (f ""))
+      -- e.g. quickcheck timeout errors
+    (Counts {errors=0, failures=0}, _) -> pure ()
+    (_                            , f) -> reject (string (f ""))
 
 checkResult
   :: Monad m
@@ -644,10 +646,10 @@ interpreter
   => FilePath
   -> SolutionConfig
   -> [String]
-  -> m (Counts, ShowS)
+  -> m (IO (Counts, ShowS))
 interpreter dirname config modules = do
   prepareInterpreter dirname config modules
-  interpret "TestHarness.run Test.test" (as :: (Counts, ShowS))
+  interpret "TestHarness.run Test.test" (as :: IO (Counts, ShowS))
 
 compiler :: MonadInterpreter m => FilePath -> SolutionConfig -> [String] -> m Bool
 compiler dirname config modules = do


### PR DESCRIPTION
An older commit removing `unsafePerformIO`. Because a change in the package database was undesirable at the time, this was put off.

I have confirmed this doesn't change anything after updating the pkgdb. 