### PR TITLE
Prevent leakage of warnings from configuration

### DIFF
--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -367,6 +367,7 @@ check reject inform path i = do
             , configHlintErrors = configHlintSuggestions <> configHlintErrors
             , configGhcWarnings = mempty
             , configHlintSuggestions = mempty
+            , configGhcLimit = pure Nothing
             }
       let others = filter ((/="SampleSolution") . fst) ms
       let content = replace "module SampleSolution" ("module " ++ m) sampleSolution

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -62,7 +62,7 @@ import GHC.Generics                     (Generic (..))
 import Language.Haskell.HLint           (hlint)
 import Language.Haskell.Interpreter
   (GhcError (..), InterpreterError (..), MonadInterpreter, OptionVal (..),
-   as, installedModulesInScope, interpret, languageExtensions, liftIO,
+   Extension(UnknownExtension), as, installedModulesInScope, interpret, languageExtensions, liftIO,
    loadModules, reset, runInterpreter, set, setImports, setTopLevelModules, searchPath)
 import Language.Haskell.Interpreter.Unsafe
   (unsafeRunInterpreterWithArgs)
@@ -554,7 +554,7 @@ compileWithArgsAndCheck
   -> m ()
 compileWithArgsAndCheck dirname reject inform config modules asError = unless (null ghcOpts) $ do
   ghcErrors <-
-    liftIO $ unsafeRunInterpreterWithArgs ghcOpts (compiler dirname config modules)
+    liftIO $ unsafeRunInterpreterWithArgs ghcOpts (compiler dirname extensions modules)
   checkResult reject ghcErrors how howMany $ const $ return ()
   where
     makeOpts xs = ("-w":) $ ("-Werror=" ++) <$> xs
@@ -565,6 +565,7 @@ compileWithArgsAndCheck dirname reject inform config modules asError = unless (n
       else (configGhcWarnings, inform)
     howMany = runIdentity $ configGhcLimit config
     rejectWithHint = rejectWithMessage reject rejectHint
+    extensions = extensionsOf config
 
 matchTemplate
   :: Monad m
@@ -679,27 +680,29 @@ checkResult reject result handleError mErrorLimit handleResult = case result of
 interpreter
   :: MonadInterpreter m
   => FilePath
-  -> SolutionConfig
+  -> [E.Extension]
   -> [String]
   -> m (IO (Counts, ShowS))
-interpreter dirname config modules = do
-  prepareInterpreter dirname config modules
+interpreter dirname exts modules = do
+  prepareInterpreter dirname exts modules
   interpret "TestHarness.run Test.test" (as :: IO (Counts, ShowS))
 
-compiler :: MonadInterpreter m => FilePath -> SolutionConfig -> [String] -> m Bool
-compiler dirname config modules = do
-  prepareInterpreter dirname config modules
+compiler :: MonadInterpreter m => FilePath -> [E.Extension] -> [String] -> m Bool
+compiler dirname exts modules = do
+  prepareInterpreter dirname exts modules
   interpret "Prelude.True" (as :: Bool)
 
-prepareInterpreter :: MonadInterpreter m => FilePath -> SolutionConfig -> [String] -> m ()
-prepareInterpreter dirname config modules = do
-  set [languageExtensions := map read (msum $ configLanguageExtensions config)]
+prepareInterpreter :: MonadInterpreter m => FilePath -> [E.Extension] -> [String] -> m ()
+prepareInterpreter dirname exts modules = do
+  set [languageExtensions := map (readExt . E.prettyExtension) exts]
   reset -- Make sure nothing is available
   set [installedModulesInScope := False]
   set [searchPath := [dirname]]
   loadModules ("TestHarness" : modules)
   setTopLevelModules modules
   setImports ["Prelude", "Test.HUnit", "TestHarness"]
+  where
+    readExt input = fromMaybe (UnknownExtension input) $ readMaybe input
 
 parse
   :: Monad m
@@ -907,7 +910,7 @@ testPhases reject inform template solutionFile modules config exts submission di
     compilation <- liftIO $ unsafeRunInterpreterWithArgs
       -- disable default warnings (bleed into error report if code doesn't compile)
       ["-w"]
-      (compiler dirname config noTest)
+      (compiler dirname exts noTest)
     checkResult reject compilation reject Nothing $ const $ return ()
 
     -- Reject if submission does not compile with provided hidden modules.
@@ -915,7 +918,7 @@ testPhases reject inform template solutionFile modules config exts submission di
     -- and displays a custom message telling students not to change type signatures.
     when (runIdentity $ allowModifying config) $ do
       compilationWithTests <- liftIO $ runInterpreter $
-        compiler dirname config modules
+        compiler dirname exts modules
       checkResult reject compilationWithTests signatureError Nothing $ const $ return ()
   ,
     -- Reject if GHC warnings configured as errors are triggered by solution.
@@ -929,7 +932,7 @@ testPhases reject inform template solutionFile modules config exts submission di
   ,
     do
     -- Reject if test suite fails for submission.
-    result <- liftIO $ runInterpreter (interpreter dirname config modules)
+    result <- liftIO $ runInterpreter (interpreter dirname exts modules)
     checkResult reject result reject Nothing $ handleCounts reject inform
   ,
     do

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -903,7 +903,10 @@ testPhases reject inform template solutionFile modules config exts submission di
     do
     -- Reject if submission does not compile with provided hidden modules,
     -- but without Test module.
-    compilation <- liftIO $ runInterpreter (compiler dirname config noTest)
+    compilation <- liftIO $ unsafeRunInterpreterWithArgs
+      -- disable default warnings (bleed into error report if code doesn't compile)
+      ["-w"]
+      (compiler dirname config noTest)
     checkResult reject compilation reject Nothing $ const $ return ()
 
     -- Reject if submission does not compile with provided hidden modules.

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -363,7 +363,7 @@ check reject inform path i = do
         reject "'messageOnCloningSampleSolution' is set, but there is no sample solution in the config."
     Just sampleSolution -> do
       let stricterConfig = config
-            { configGhcErrors = configGhcWarnings <> configGhcErrors
+            { configGhcErrors = ("all":) <$> configGhcWarnings <> configGhcErrors
             , configHlintErrors = configHlintSuggestions <> configHlintErrors
             , configGhcWarnings = mempty
             , configHlintSuggestions = mempty

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -348,7 +348,7 @@ check
   -> m ()
 check reject inform path i = do
   checkUnsafe reject i
-  (config, exts, (m,s), ms) <- processConfig reject inform i
+  (config@SolutionConfig{..}, exts, (m,s), ms) <- processConfig reject inform i
   checkUniqueness (m : map fst ms)
   inform $ string $ "Parsing template module " <> m
   void $ parse reject exts s
@@ -357,15 +357,21 @@ check reject inform path i = do
   -- This step is currently optional and will not run if no sample solution is provided
   case mSampleSolution of
     Nothing -> do
-      when (runIdentity $ provideSampleSolution config) $
+      when (runIdentity provideSampleSolution) $
         reject "'provideSampleSolution' is set, but there is no sample solution in the config."
-      whenJust (runIdentity $ messageOnCloningSampleSolution config) $ const $
+      whenJust (runIdentity messageOnCloningSampleSolution) $ const $
         reject "'messageOnCloningSampleSolution' is set, but there is no sample solution in the config."
     Just sampleSolution -> do
+      let stricterConfig = config
+            { configGhcErrors = configGhcWarnings <> configGhcErrors
+            , configHlintErrors = configHlintSuggestions <> configHlintErrors
+            , configGhcWarnings = mempty
+            , configHlintSuggestions = mempty
+            }
       let others = filter ((/="SampleSolution") . fst) ms
       let content = replace "module SampleSolution" ("module " ++ m) sampleSolution
       (modules, solutionFile) <- writeModules (m, content) others path
-      sequence_ $ testPhases reject inform s solutionFile modules config exts content path
+      sequence_ $ testPhases reject inform s solutionFile modules stricterConfig exts content path
   where
     parseModule exts (m, s) = do
       inform $ string $ "Parsing module " <> m

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -363,7 +363,7 @@ check reject inform path i = do
         reject "'messageOnCloningSampleSolution' is set, but there is no sample solution in the config."
     Just sampleSolution -> do
       let stricterConfig = config
-            { configGhcErrors = ("all":) <$> configGhcWarnings <> configGhcErrors
+            { configGhcErrors = configGhcWarnings <> configGhcErrors
             , configHlintErrors = configHlintSuggestions <> configHlintErrors
             , configGhcWarnings = mempty
             , configHlintSuggestions = mempty


### PR DESCRIPTION
closes #13 

- promote warnings to errors for sample solution tests
- additionally enforce `-Wall`, this also indirectly covers `-Wextended-warnings` and therefore `-Wx-partial`

This should make sure the configs are warning free.

@jvoigtlaender this is a bit different from what you last suggested in #13, but I think it accomplishes the same goal. The config should fail on one of the interpreter runs respecting the config GHC options with `-Wall` if it would fail in one of the compiles ignoring the options. Do you see any problems with this approach?

