### PR TITLE
Add option for ensuring specific line length

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -13,6 +13,7 @@ IOTASKS
 KPatterns
 Leijen
 lhs
+linebreak
 listify
 NPlus
 PCRE

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -78,7 +78,7 @@ import System.FilePath (
   )
 import Test.HUnit                       (Counts (..))
 import Text.PrettyPrint.Leijen.Text
-  (Doc, nest, text, vcat)
+  (Doc, (<+>), int, linebreak, nest, punctuate, text, vcat)
 import Text.Read                        (readMaybe)
 import Text.Regex.PCRE.Heavy            (re, sub)
 
@@ -108,9 +108,10 @@ defaultCode = BS.unpack (encode defaultSolutionConfig) ++
 \# configHlintSuggestions      - hlint hints to provide as suggestions
 \# configLanguageExtensions    - this sets LanguageExtensions for hlint as well
 \# configModules               - DEPRECATED (will be ignored)
+\# maxLineLength               - submissions with lines longer than this value are rejected
 \# syntaxCutoff                - determines the last step in the syntax phase (later steps are considered semantics)
 \#                               possible values (and also the order of steps):
-\#                                 Compilation, GhcErrors, HlintErrors, TemplateMatch, TestSuite
+\#                                 CodeWidth, Compilation, GhcErrors, HlintErrors, TemplateMatch, TestSuite
 \#                               default on omission is TemplateMatch; steps after TestSuite are (in this order):
 \#                                 GhcWarnings, HlintSuggestions
 \# disableSemantics            - will prevent the semantics phase (as determined by syntaxCutoff) from running;
@@ -197,7 +198,8 @@ Also available are the following modules:
  -}|]
 
 data FeedbackPhase
-  = Compilation
+  = CodeWidth
+  | Compilation
   | GhcErrors
   | HlintErrors
   | TemplateMatch
@@ -221,6 +223,7 @@ data FSolutionConfig m = SolutionConfig {
     configHlintSuggestions      :: m [String],
     configLanguageExtensions    :: m [String],
     configModules               :: m [String],
+    maxLineLength               :: m (Maybe Natural),
     provideSampleSolution       :: m Bool,
     messageOnCloningSampleSolution :: m (Maybe String),
     disableSemantics            :: m Bool,
@@ -256,6 +259,7 @@ defaultSolutionConfig = SolutionConfig {
     configHlintSuggestions      = Just [],
     configLanguageExtensions    = Just ["NPlusKPatterns","ScopedTypeVariables"],
     configModules               = Nothing,
+    maxLineLength               = Just Nothing,
     provideSampleSolution       = Just False,
     messageOnCloningSampleSolution = Just Nothing,
     disableSemantics            = Just False,
@@ -280,6 +284,7 @@ toSolutionConfigOpt SolutionConfig {..} = runIdentity $ SolutionConfig
   <*> fmap Just configHlintSuggestions
   <*> fmap Just configLanguageExtensions
   <*> fmap Just configModules
+  <*> fmap Just maxLineLength
   <*> fmap Just provideSampleSolution
   <*> fmap Just messageOnCloningSampleSolution
   <*> fmap Just disableSemantics
@@ -306,6 +311,7 @@ finaliseConfigs = finaliseConfig . foldl combineConfigs emptyConfig
       <*> fmap Identity configHlintSuggestions
       <*> fmap Identity configLanguageExtensions
       <*> fmap Identity configModules
+      <*> fmap Identity maxLineLength
       <*> fmap Identity provideSampleSolution
       <*> fmap Identity messageOnCloningSampleSolution
       <*> fmap Identity disableSemantics
@@ -327,6 +333,7 @@ finaliseConfigs = finaliseConfig . foldl combineConfigs emptyConfig
         configHlintSuggestions      = configHlintSuggestions      x <|> configHlintSuggestions      y,
         configLanguageExtensions    = configLanguageExtensions    x <|> configLanguageExtensions    y,
         configModules               = Just [],
+        maxLineLength               = maxLineLength               x <|> maxLineLength               y,
         provideSampleSolution       = provideSampleSolution       x <|> provideSampleSolution       y,
         messageOnCloningSampleSolution = messageOnCloningSampleSolution x <|> messageOnCloningSampleSolution y,
         disableSemantics            = disableSemantics            x <|> disableSemantics            y,
@@ -349,6 +356,7 @@ finaliseConfigs = finaliseConfig . foldl combineConfigs emptyConfig
         configHlintSuggestions      = Nothing,
         configLanguageExtensions    = Nothing,
         configModules               = Nothing,
+        maxLineLength               = Nothing,
         provideSampleSolution       = Nothing,
         messageOnCloningSampleSolution = Nothing,
         disableSemantics            = Nothing,
@@ -943,6 +951,10 @@ testPhases
   -> [m ()]
 testPhases reject inform template solutionFile modules config exts submission dirname =
   [
+    -- Reject if submission has lines violating the configured maximum line length.
+    -- Only checked if the setting is configured.
+    mapM_ (checkLineLength reject submission) $ runIdentity $ maxLineLength config
+  ,
     do
     -- Reject if submission does not compile with provided hidden modules,
     -- but without Test module.
@@ -990,3 +1002,25 @@ testPhases reject inform template solutionFile modules config exts submission di
       Your code is not compatible with the test suite.
       Please do not change type signatures in the given code template.
       |]
+
+checkLineLength :: Applicative m => (forall a. Doc -> m a) -> String -> Natural -> m ()
+checkLineLength reject code maxLength = case hasLonger of
+  []     -> pure ()
+  xs     -> rejectWithHint $ separated
+    [ "Your submission contains overlong lines:"
+    , separated xs
+    , "The maximum line length allowed is" <+> string (show maxLength) <> "."
+    ]
+  where
+    codeLines = lines code
+    hasLonger =
+      [ format x
+      | x@(_,l) <- zip [1..] codeLines
+      , length l > fromIntegral maxLength
+      ]
+    format (i,l) = nest 2 $ vcat
+      [ "Line" <+> int i <+> "(length" <+> int (length l) <> "):"
+      , string l
+      ]
+    separated = vcat . punctuate linebreak
+    rejectWithHint = rejectWithMessage reject rejectHint

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -509,7 +509,7 @@ grade withSyntax withSemantics reject inform dirname task submission = do
       (const $ pure ())
       task
     (modules, solutionFile) <- if runIdentity $ fmap (== CodeWidth) syntaxCutoff &&^ disableSemantics
-      -- completely skip file writing if code length is the only syntax phase action
+      -- Completely skip file writing if code length is the only syntax phase action
       -- and semantics phase is disabled.
       then pure (undefined, undefined)
       else writeModules (moduleName', submission) others dirname
@@ -1009,8 +1009,8 @@ testPhases reject inform template solutionFile modules config exts submission di
 
 checkLineLength :: Applicative m => (forall a. Doc -> m a) -> String -> Natural -> m ()
 checkLineLength reject code maxLength = case hasLonger of
-  []     -> pure ()
-  xs     -> rejectWithHint $ separated
+  [] -> pure ()
+  xs -> rejectWithHint $ separated
     [ "Your submission contains overlong lines:"
     , separated xs
     , "The maximum line length allowed is" <+> string (show maxLength) <> "."
@@ -1018,12 +1018,12 @@ checkLineLength reject code maxLength = case hasLonger of
   where
     codeLines = lines code
     hasLonger =
-      [ format (i, l, lineLength)
+      [ format i l lineLength
       | (i, l) <- zip [1..] codeLines
       , let lineLength = length l
       , fromIntegral lineLength > maxLength
       ]
-    format (i, l, lineLength) = nest 2 $ vcat
+    format i l lineLength = nest 2 $ vcat
       [ "Line" <+> int i <+> "(length" <+> int lineLength <> "):"
       , string l
       ]

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -1018,12 +1018,13 @@ checkLineLength reject code maxLength = case hasLonger of
   where
     codeLines = lines code
     hasLonger =
-      [ format x
-      | x@(_,l) <- zip [1..] codeLines
-      , length l > fromIntegral maxLength
+      [ format (i, l, lineLength)
+      | (i, l) <- zip [1..] codeLines
+      , let lineLength = length l
+      , fromIntegral lineLength > maxLength
       ]
-    format (i,l) = nest 2 $ vcat
-      [ "Line" <+> int i <+> "(length" <+> int (length l) <> "):"
+    format (i, l, lineLength) = nest 2 $ vcat
+      [ "Line" <+> int i <+> "(length" <+> int lineLength <> "):"
       , string l
       ]
     separated = vcat . punctuate linebreak

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -42,7 +42,7 @@ import qualified Haskell.Template.Match as Match (test)
 
 import Control.Applicative              ((<|>))
 import Control.Monad                    (forM, guard, msum, unless, void, when)
-import Control.Monad.Extra              (whenJust)
+import Control.Monad.Extra              ((&&^), whenJust)
 import Control.Monad.IO.Class           (MonadIO)
 import Data.Char                        (isUpper)
 import Data.Functor.Identity            (Identity (..))
@@ -204,7 +204,7 @@ data FeedbackPhase
   | HlintErrors
   | TemplateMatch
   | TestSuite
-  deriving (Enum, Generic, Show, FromJSON, ToJSON)
+  deriving (Enum, Eq, Generic, Show, FromJSON, ToJSON)
 
 data FSolutionConfig m = SolutionConfig {
     allowAdding                 :: m Bool,
@@ -504,22 +504,26 @@ grade
   -- ^ whether the conditions outlined in the description apply or not
 grade withSyntax withSemantics reject inform dirname task submission = do
     withSyntax $ checkUnsafe reject submission
-    (config, exts, (moduleName', template), others) <- processConfig
+    (config@SolutionConfig{..}, exts, (moduleName', template), others) <- processConfig
       (rejectWithMessage reject $ string informTutorMessage)
       (const $ pure ())
       task
-    (modules, solutionFile) <- writeModules (moduleName', submission) others dirname
+    (modules, solutionFile) <- if runIdentity $ fmap (== CodeWidth) syntaxCutoff &&^ disableSemantics
+      -- completely skip file writing if code length is the only syntax phase action
+      -- and semantics phase is disabled.
+      then pure (undefined,undefined)
+      else writeModules (moduleName', submission) others dirname
     let
-     (syntax, semantics) = splitAt (fromEnum (syntaxCutoff config) + 1)
+     (syntax, semantics) = splitAt (fromEnum syntaxCutoff + 1)
       $ testPhases reject inform template solutionFile modules config exts submission dirname
     withSyntax $ sequence_ syntax
-    if runIdentity $ disableSemantics config
+    if runIdentity disableSemantics
     then pure False
     else do
      withSemantics $ sequence_ semantics
      case
       (,) <$> lookup "SampleSolution" others
-          <*> runIdentity (messageOnCloningSampleSolution config)
+          <*> runIdentity messageOnCloningSampleSolution
       of
         Nothing                       -> pure False
         Just (sampleSolution,message) -> catchSampleSolutionClone

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -511,7 +511,7 @@ grade withSyntax withSemantics reject inform dirname task submission = do
     (modules, solutionFile) <- if runIdentity $ fmap (== CodeWidth) syntaxCutoff &&^ disableSemantics
       -- completely skip file writing if code length is the only syntax phase action
       -- and semantics phase is disabled.
-      then pure (undefined,undefined)
+      then pure (undefined, undefined)
       else writeModules (moduleName', submission) others dirname
     let
      (syntax, semantics) = splitAt (fromEnum syntaxCutoff + 1)


### PR DESCRIPTION
closes #16 

- Reject if submission contains any lines with length > `maxLineLength` option
- Display all offending lines at once, including their location, content and total length
  <img width="3160" height="846" alt="Screenshot From 2026-05-05 15-29-45" src="https://github.com/user-attachments/assets/9ede1ff9-e90a-436c-a8af-3304d151093c" />

- add this as a separate syntax phase for `syntaxCutoff` (`CodeWidth`)
- Do not write any files while grading if `syntaxCutoff` is set to `CodeWidth` and `disableSemantics` is set.
 
Question: Should the config checker prevent setting `syntaxCutoff` to `CodeWidth` if `maxLineLength` is unset? I wasn't sure about that, since it may still be useful to directly accept any submission without considering its content (similar to not writing files if we only check the line length). 