### PR TITLE
defensive line length check in config validator

### DIFF
--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -381,7 +381,7 @@ check reject inform path i = do
   checkUniqueness (m : map fst ms)
   inform $ string $ "Parsing template module " <> m
   void $ parse reject exts s
-  mapM_ (checkLineLength reject s) $ runIdentity maxLineLength
+  mapM_ (checkLineLength reject s . subtract 1) $ runIdentity maxLineLength
   void $ parseModule exts `mapM` ms
   let mSampleSolution = lookup "SampleSolution" ms
   -- This step is currently optional and will not run if no sample solution is provided
@@ -401,7 +401,7 @@ check reject inform path i = do
             }
       let others = filter ((/="SampleSolution") . fst) ms
       let content = replace "module SampleSolution" ("module " ++ m) sampleSolution
-      mapM_ (checkLineLength reject content) $ runIdentity maxLineLength
+      mapM_ (checkLineLength reject content . subtract 3) $ runIdentity maxLineLength
       (modules, solutionFile) <- writeModules (m, content) others path
       sequence_ $ testPhases reject inform s solutionFile modules stricterConfig exts content path
   where


### PR DESCRIPTION
To be prepared for whitespace watermarking in the template and line-outcomments in the sample solution.
