### PR TITLE
Test evaluation no longer has everything in scope

### DIFF
--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -743,9 +743,10 @@ prepareInterpreter dirname exts modules = do
   reset -- Make sure nothing is available
   set [installedModulesInScope := False]
   set [searchPath := [dirname]]
+  -- All modules can be imported in source files
   loadModules ("TestHarness" : modules)
-  setTopLevelModules modules
-  setImports ["Prelude", "Test.HUnit", "TestHarness"]
+  -- All export items from these modules are in scope for the interpreter evaluation.
+  setImports $ ["Prelude", "Test.HUnit", "TestHarness"] ++ ["Test" | "Test" `elem` modules]
   where
     readExt input = fromMaybe (UnknownExtension input) $ readMaybe input
 

--- a/src/Haskell/Template/Task.hs
+++ b/src/Haskell/Template/Task.hs
@@ -745,7 +745,7 @@ prepareInterpreter dirname exts modules = do
   set [searchPath := [dirname]]
   -- All modules can be imported in source files
   loadModules ("TestHarness" : modules)
-  -- All export items from these modules are in scope for the interpreter evaluation.
+  -- All export items from these modules are in scope for the interpreter evaluation
   setImports $ ["Prelude", "Test.HUnit", "TestHarness"] ++ ["Test" | "Test" `elem` modules]
   where
     readExt input = fromMaybe (UnknownExtension input) $ readMaybe input


### PR DESCRIPTION
I ran into a problem while fixing the currently planned IOTasks: In those `type IO = IOrep` is defined and that triggered an error within the interpreter, because both `Prelude.IO` and this is in scope. Hiding the type in the import of the Task file did not have any effect.

It turns out that for the evaluation of the tests https://github.com/fmidue/haskell-template-task/blob/4e97004b284cca32881c76774b357dfa87568ff0/src/Haskell/Template/Task.hs#L733 everything in the loaded modules is in scope, even stuff that is explicitly not exported. So it is currently not possible to have such type synonyms inside the template/solution.

This is quite weird: I do not remember this being any different in the previous year, yet no error occured. My guess is that before #37 there was no mention of the IO type in the test result handling. So, even though this IO synonym was in scope, it did not cause a problem. Now there is explicit mention of IO, so the clash has an effect.

Luckily, this is easy to fix: `setTopLevelModules modules` is responsible for having everything in scope and can just be removed. Afterwards, you can still import the modules in code as usual, they are just not implicitly available in the above evaluation.

I'm assuming this was a mistake/oversight. But maybe there's an actual corner case why everything has to be in scope, that I did not think of?

