### PR TITLE
Automatically deploy Haddock documentation to GitHub Pages

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,0 +1,8 @@
+{
+  "threshold": 2,
+  "reporters": ["consoleFull"],
+  "ignore": ["**/.github/**"],
+  "minLines": 2,
+  "max-lines": 2000,
+  "absolute": true
+}

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -1,0 +1,72 @@
+---
+name: Haddock to GitHub pages
+
+on:
+  workflow_run:
+    workflows: ["Haskell CI"]
+    branches: [master]
+    types: completed
+
+permissions: read-all
+
+jobs:
+  build:
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Stack
+        id: cache-stack-unix
+        uses: actions/cache@v5
+        with:
+          path: ~/.stack
+          key: ubuntu-latest-stack-stack-home-${{ hashFiles('stack.yaml') }}-${{ hashFiles('**/package.yaml') }}
+
+      - name: Setup stack
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-no-global: true
+
+      - name: install/restore PCRE
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libpcre3 libpcre3-dev
+          version: 1.0
+
+      - name: Build Haddock
+        id: haddock
+        run: |
+          stack haddock \
+            --haddock-arguments "--hyperlinked-source --quickjump --title=Haskell.Template"
+          echo "doc_path=$(stack path --local-doc-root)" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          name: github-pages
+          path: ${{steps.haddock.outputs.doc_path}}
+          retention-days: 1
+
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,6 +31,8 @@ jobs:
         uses: super-linter/super-linter/slim@v8.3.2
         env:
           YAML_ERROR_ON_WARNING: true
+          # Fails to parse Haddock workflow
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           GITHUB_ACTIONS_COMMAND_ARGS: -shellcheck=
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_YAML_PRETTIER: false


### PR DESCRIPTION
Closes #25

A test deployment can be viewed here: <https://nimec01.github.io/haskell-template-task/>